### PR TITLE
Use editor.document.uri for URI

### DIFF
--- a/Scripts/Linter.js
+++ b/Scripts/Linter.js
@@ -52,13 +52,12 @@ class Linter {
 
   processDocument(editor) {
     const relativePath = nova.workspace.relativizePath(editor.document.path);
-    const uri = `file://${editor.document.path}`;
     const contentRange = new Range(0, editor.document.length);
     const content = editor.document.getTextInRange(contentRange);
     const process = new LinterProcess(relativePath, content);
 
     process.onComplete((offenses) => {
-      this.issues.set(uri, offenses.map(offense => offense.issue));
+      this.issues.set(editor.document.uri, offenses.map(offense => offense.issue));
     });
 
     process.execute();


### PR DESCRIPTION
This is should fix #2. It uses `editor.document.uri` as URI when calling `IssueCollection.set()`